### PR TITLE
chore: add Grid Menu styling to grid with `autoHeight`

### DIFF
--- a/src/examples/slickgrid/Example21.tsx
+++ b/src/examples/slickgrid/Example21.tsx
@@ -9,7 +9,9 @@ import {
   GridOption
 } from '../../slickgrid-react';
 import React from 'react';
+
 import BaseSlickGridState from './state-slick-grid-base';
+import './example21.scss';
 
 interface Props { }
 interface State extends BaseSlickGridState {
@@ -61,27 +63,24 @@ export default class Example21 extends React.Component<Props, State> {
     const columnDefinitions: Column[] = [
       {
         id: 'title', name: 'Title', field: 'title',
-        width: 100,
-        sortable: true,
+        width: 100, sortable: true,
         type: FieldType.string
       },
       {
         id: 'duration', name: 'Duration (days)', field: 'duration',
-        width: 100,
-        sortable: true,
+        width: 100, sortable: true,
         type: FieldType.number
       },
       {
         id: 'complete', name: '% Complete', field: 'percentComplete',
-        width: 100,
+        width: 100, sortable: true,
         formatter: Formatters.percentCompleteBar,
         type: FieldType.number
       },
       {
         id: 'start', name: 'Start', field: 'start',
-        width: 100,
+        width: 100, sortable: true,
         formatter: Formatters.dateIso,
-        sortable: true,
         type: FieldType.date
       },
       {
@@ -92,7 +91,7 @@ export default class Example21 extends React.Component<Props, State> {
       },
       {
         id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven',
-        width: 100,
+        width: 100, sortable: true,
         formatter: Formatters.checkmark,
         type: FieldType.number
       }
@@ -114,7 +113,6 @@ export default class Example21 extends React.Component<Props, State> {
       enableFiltering: true,
       showHeaderRow: false, // hide the filter row (header row)
 
-      enableGridMenu: false, // disable grid menu & remove vertical scroll
       alwaysShowVerticalScroll: false,
       enableColumnPicker: true,
       enableCellNavigation: true,

--- a/src/examples/slickgrid/Example32.tsx
+++ b/src/examples/slickgrid/Example32.tsx
@@ -10,15 +10,16 @@ import {
   Formatters,
   GridOption,
   LongTextEditorOption,
+  ReactGridInstance,
+  ReactSlickgrid,
   SlickGrid,
   SlickNamespace,
   SortComparers,
-} from '@slickgrid-universal/common';
+} from '../../slickgrid-react';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import React from 'react';
 
 import BaseSlickGridState from './state-slick-grid-base';
-import { ReactGridInstance, ReactSlickgrid } from '../../slickgrid-react';
 import './example32.scss'; // provide custom CSS/SASS styling
 
 const NB_ITEMS = 5000;

--- a/src/examples/slickgrid/Example33.tsx
+++ b/src/examples/slickgrid/Example33.tsx
@@ -8,14 +8,15 @@ import {
   Formatters,
   GridOption,
   MenuCommandItemCallbackArgs,
+  ReactGridInstance,
+  ReactSlickgrid,
   OperatorType,
   SlickGrid,
-} from '@slickgrid-universal/common';
+} from '../../slickgrid-react';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import React from 'react';
 
-import { ReactGridInstance, ReactSlickgrid } from '../../slickgrid-react';
 import BaseSlickGridState from './state-slick-grid-base';
 
 const NB_ITEMS = 500;

--- a/src/examples/slickgrid/Example34.tsx
+++ b/src/examples/slickgrid/Example34.tsx
@@ -8,12 +8,13 @@ import {
   Formatters,
   GridOption,
   GroupTotalFormatters,
-} from '@slickgrid-universal/common';
+  ReactGridInstance,
+  ReactSlickgrid,
+} from '../../slickgrid-react';
 import { faker } from '@faker-js/faker';
 import sparkline from '@fnando/sparkline';
 import React from 'react';
 
-import { ReactGridInstance, ReactSlickgrid } from '../../slickgrid-react';
 import BaseSlickGridState from './state-slick-grid-base';
 import './example34.scss';
 

--- a/src/examples/slickgrid/example21.scss
+++ b/src/examples/slickgrid/example21.scss
@@ -1,0 +1,12 @@
+// sort indication will show behind Grid Menu since we don't have scroll,
+// we can offset these icons to fix that
+#grid21 {
+    .slick-header-column:last-child {
+        .slick-header-menu-button,
+        .slick-resizable-handle,
+        .slick-sort-indicator,
+        .slick-sort-indicator-numbered {
+            margin-right: 18px; // grid menu icon width
+        }
+    }
+}


### PR DESCRIPTION
- add margin on the last column so that sort icon & header menu doesn't fall behind the grid menu

![image](https://user-images.githubusercontent.com/643976/206573733-1de3a3f9-ee6c-4004-af06-6d8a239ea647.png)
