### PR TITLE
fix(presets): dynamic columns should be auto-inserted with Grid Presets

### DIFF
--- a/src/slickgrid-react/components/slickgrid-react.tsx
+++ b/src/slickgrid-react/components/slickgrid-react.tsx
@@ -1266,27 +1266,47 @@ export class SlickgridReact extends React.Component<SlickgridReactProps, State> 
     }
   }
 
+  protected insertDynamicPresetColumns(columnId: string, gridPresetColumns: Column[]) {
+    if (this._columnDefinitions) {
+      const columnPosition = this._columnDefinitions.findIndex(c => c.id === columnId);
+      if (columnPosition >= 0) {
+        const dynColumn = this._columnDefinitions[columnPosition];
+        if (dynColumn?.id === columnId && !gridPresetColumns.some(c => c.id === columnId)) {
+          columnPosition > 0
+            ? gridPresetColumns.splice(columnPosition, 0, dynColumn)
+            : gridPresetColumns.unshift(dynColumn);
+        }
+      }
+    }
+  }
+
   /** Load any possible Columns Grid Presets */
   protected loadColumnPresetsWhenDatasetInitialized() {
     // if user entered some Columns "presets", we need to reflect them all in the grid
     if (this.grid && this.gridOptions.presets && Array.isArray(this.gridOptions.presets.columns) && this.gridOptions.presets.columns.length > 0) {
-      const gridColumns: Column[] = this.gridStateService.getAssociatedGridColumns(this.grid, this.gridOptions.presets.columns);
-      if (gridColumns && Array.isArray(gridColumns) && gridColumns.length > 0) {
-        // make sure that the checkbox selector is also visible if it is enabled
+      const gridPresetColumns: Column[] = this.gridStateService.getAssociatedGridColumns(this.grid, this.gridOptions.presets.columns);
+      if (gridPresetColumns && Array.isArray(gridPresetColumns) && gridPresetColumns.length > 0 && Array.isArray(this._columnDefinitions)) {
+        // make sure that the dynamic columns are included in presets (1.Row Move, 2. Row Selection, 3. Row Detail)
+        if (this.gridOptions.enableRowMoveManager) {
+          const rmmColId = this.gridOptions?.rowMoveManager?.columnId ?? '_move';
+          this.insertDynamicPresetColumns(rmmColId, gridPresetColumns);
+        }
         if (this.gridOptions.enableCheckboxSelector) {
-          const checkboxColumn = (Array.isArray(this._columnDefinitions) && this._columnDefinitions.length > 0) ? this._columnDefinitions[0] : null;
-          if (checkboxColumn && checkboxColumn.id === '_checkbox_selector' && gridColumns[0].id !== '_checkbox_selector') {
-            gridColumns.unshift(checkboxColumn);
-          }
+          const chkColId = this.gridOptions?.checkboxSelector?.columnId ?? '_checkbox_selector';
+          this.insertDynamicPresetColumns(chkColId, gridPresetColumns);
+        }
+        if (this.gridOptions.enableRowDetailView) {
+          const rdvColId = this.gridOptions?.rowDetailView?.columnId ?? '_detail_selector';
+          this.insertDynamicPresetColumns(rdvColId, gridPresetColumns);
         }
 
         // keep copy the original optional `width` properties optionally provided by the user.
         // We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
-        gridColumns.forEach(col => col.originalWidth = col.width);
+        gridPresetColumns.forEach(col => col.originalWidth = col.width);
 
         // finally set the new presets columns (including checkbox selector if need be)
-        this.grid.setColumns(gridColumns);
-        this.sharedService.visibleColumns = gridColumns;
+        this.grid.setColumns(gridPresetColumns);
+        this.sharedService.visibleColumns = gridPresetColumns;
       }
     }
   }


### PR DESCRIPTION
- there are 3 dynamically created columns (RowMove, RowSelection & RowDetail) and all 3 should be auto-inserted when enabled and used with columns presets
- the 2nd issue will be fixed in Slickgrid-Universal, the issue is when Row Detail & Row Selection are used together, an extra checkbox appears in the filter section of the RowDetail column when it shouldn't (see 2nd print screen)
  - this is fixed in Slickgrid-Universal [PR 938](https://github.com/ghiscoding/slickgrid-universal/pull/938)