### PR TITLE
fix: improve build & types exports for all targets, Node, CJS/ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,25 @@
     "plugin",
     "slickgrid"
   ],
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
+  "typesVersions": {
+    ">=4.2": {
+      "*": [
+        "dist/types/*"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/cjs/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "homepage": "https://github.com/ghiscoding/slickgrid-react",
   "bugs": {
     "url": "https://github.com/ghiscoding/slickgrid-react/issues"
@@ -36,25 +55,6 @@
       "name": "Joel Peña"
     }
   ],
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./*": "./*"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/index.d.ts"
-      ]
-    }
-  },
-  "types": "dist/types/index.d.ts",
   "scripts": {
     "build:demo": "webpack --env production",
     "delete:dist": "rimraf dist",

--- a/src/slickgrid-react/tsconfig.build.json
+++ b/src/slickgrid-react/tsconfig.build.json
@@ -2,9 +2,9 @@
     "compilerOptions": {
         "module": "esnext",
         "moduleResolution": "node",
-        "target": "es2017",
+        "target": "es2018",
         "lib": [
-            "es2017",
+            "es2018",
             "dom"
         ],
         "typeRoots": [
@@ -30,9 +30,7 @@
     },
     "exclude": [
         ".vscode",
-        "src/react_project",
         "src/examples",
-        "src/resources",
         "src/test",
         "**/*.spec.ts",
         "**/*.scss"


### PR DESCRIPTION
- build only 1 `dist/types` folder for all target
- previous implementation didn't pass all type exports as can be shown in [Are the types wrong?](https://arethetypeswrong.github.io)