### PR TITLE
fix: Filter `model` is now `FilterConstructor` and shouldn't be newed

### DIFF
--- a/docs/column-functionalities/filters/custom-filter.md
+++ b/docs/column-functionalities/filters/custom-filter.md
@@ -26,7 +26,7 @@ You can also create your own Custom Filter with any html/css you want and/or jQu
      { id: 'description', name: 'Description', field: 'description', type: FieldType.string,
        filterable: true,
        filter: {
-          model: new CustomInputFilter() // create a new instance to make each Filter independent from each other
+          model: CustomInputFilter // create a new instance to make each Filter independent from each other
        }
      }
    ];

--- a/src/examples/slickgrid/Example23.tsx
+++ b/src/examples/slickgrid/Example23.tsx
@@ -126,7 +126,7 @@ class Example23 extends React.Component<Props, State> {
         id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80,
         type: FieldType.string,
         filter: {
-          model: new CustomInputFilter(), // create a new instance to make each Filter independent from each other
+          model: CustomInputFilter, // create a new instance to make each Filter independent from each other
           enableTrimWhiteSpace: true // or use global "enableFilterTrimWhiteSpace" to trim on all Filters
         }
       },

--- a/src/examples/slickgrid/Example4.tsx
+++ b/src/examples/slickgrid/Example4.tsx
@@ -100,7 +100,7 @@ export default class Example4 extends React.Component<Props, State> {
         id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80,
         type: FieldType.string,
         filter: {
-          model: new CustomInputFilter(), // create a new instance to make each Filter independent from each other customFilter
+          model: CustomInputFilter, // create a new instance to make each Filter independent from each other customFilter
           enableTrimWhiteSpace: true
         }
       },


### PR DESCRIPTION
- the Filter `model` prop should be a constructor and it shouldn't newed (instantiated), it was defined like so in the docs and Wikis but that was actually wrong
- ref Slickgrid-Universal [PR 1430](https://github.com/ghiscoding/slickgrid-universal/pull/1430)