### PR TITLE
fix: revisit package `exports` to pass "are the types wrong"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },


### PR DESCRIPTION
- a recent commit made the `exports` a bit simpler but displays 1 unexpected syntax error on [are the types wrong](https://arethetypeswrong.github.io/?p=slickgrid-react%403.1.0)
- use the same `exports` that we use in `multiple-select-vanilla` since that one doesn't display that error