### PR TITLE
chore: remove deprecated `internalColumnEditor` usage

### DIFF
--- a/src/examples/slickgrid/Example3.tsx
+++ b/src/examples/slickgrid/Example3.tsx
@@ -38,10 +38,6 @@ const myCustomTitleValidator: EditorValidator = (value: any) => {
   // const gridOptions = grid.getOptions() as GridOption;
   // const i18n = gridOptions.i18n;
 
-  // to get the editor object, you'll need to use 'internalColumnEditor'
-  // don't use 'editor' property since that one is what SlickGrid uses internally by it's editor factory
-  // const columnEditor = args && args.column && args.column.internalColumnEditor;
-
   if (value === null || value === undefined || !value.length) {
     return { valid: false, msg: 'This is a required field' };
   } else if (!/^Task\s\d+$/.test(value)) {
@@ -717,15 +713,7 @@ export default class Example3 extends React.Component<Props, State> {
       columnDefinitions: this.state.columnDefinitions.slice(),
     }));
 
-    // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
-    // you MUST use the code below, first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
-    // in other words, SlickGrid is not using the same as Slickgrid-React uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
-    const allColumns = this.reactGrid.gridService.getAllColumnDefinitions();
-    const allOriginalColumns = allColumns.map((column) => {
-      column.editor = column.internalColumnEditor;
-      return column;
-    });
     // remove your column the full set of columns
     // and use slice or spread [...] to trigger an React dirty change
     allOriginalColumns.pop();

--- a/src/examples/slickgrid/custom-inputEditor.tsx
+++ b/src/examples/slickgrid/custom-inputEditor.tsx
@@ -26,7 +26,7 @@ export class CustomInputEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor ?? {};
+    return this.columnDef?.editor ?? {};
   }
 
   /** Get the Validator function, can be passed in Editor property or Column Definition */

--- a/src/slickgrid-react/components/slickgrid-react.tsx
+++ b/src/slickgrid-react/components/slickgrid-react.tsx
@@ -1555,6 +1555,7 @@ export class SlickgridReact<TData = any> extends React.Component<SlickgridReactP
         return {
           ...column,
           editorClass: column.editor?.model,
+          // @deprecated `internalColumnEditor`, this will no longer be useful in the next major
           internalColumnEditor: { ...column.editor }
         };
       }


### PR DESCRIPTION
- users can still call `internalColumnEditor` but since it's deprecated, then it's better to remove it from all demos