### PR TITLE
fix: add missing peer dep on React

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
     "i18next": "^23.16.5",
     "sortablejs": "^1.15.3"
   },
+  "peerDependencies": {
+    "react": ">=18.0.0"
+  },
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.5",
     "@arethetypeswrong/cli": "^0.16.4",


### PR DESCRIPTION
- we should make sure user installs React 18.0 or higher